### PR TITLE
Support null bytes in parser feed

### DIFF
--- a/bench.lua
+++ b/bench.lua
@@ -4,7 +4,7 @@ local parser = spp:new()
 n = 500000
 
 ---------------------- SPP Implemetation ---------------
-start_at = os.time()
+start_at = os.clock()
 
 for i = 0, n do
     local s = tostring(i)
@@ -14,7 +14,7 @@ for i = 0, n do
     assert(t[2] == tostring(i))
 end
 
-end_at = os.time()
+end_at = os.clock()
 
 print(string.format('spp parser: %d in %fs => %fops', n,
 end_at - start_at, n / (end_at - start_at)))
@@ -82,7 +82,7 @@ function Parser.get(self)
 end
 
 local parser = Parser:new()
-start_at = os.time()
+start_at = os.clock()
 
 for i = 0, n do
     local s = tostring(i)
@@ -92,7 +92,7 @@ for i = 0, n do
     assert(t[2] == tostring(i))
 end
 
-end_at = os.time()
+end_at = os.clock()
 
 print(string.format('lua parser: %d in %fs => %fops', n,
 end_at - start_at, n / (end_at - start_at)))

--- a/src/spp.c
+++ b/src/spp.c
@@ -43,9 +43,9 @@ spp_clear(spp_t *spp)
  * Feed a spp parser with data.
  */
 int
-spp_feed(spp_t *spp, char *data)
+spp_feed(spp_t *spp, char *data, size_t size)
 {
-    int res = hbuf_puts(spp->buf, data);
+    int res = hbuf_put(spp->buf, (uint8_t *)data, size);
 
     if (res == HBUF_ENOMEM)
         return SPP_ENOMEM;

--- a/src/spp.h
+++ b/src/spp.h
@@ -47,7 +47,7 @@ typedef struct spp_st {
 
 /* Public API for the protocol parser */
 spp_t* spp_new();
-int spp_feed(spp_t *, char *);
+int spp_feed(spp_t *, char *, size_t);
 void spp_free(spp_t *);
 int spp_parse(spp_t *);
 void spp_clear(spp_t *);

--- a/src/spp_lua.c
+++ b/src/spp_lua.c
@@ -39,8 +39,13 @@ parser_feed(lua_State *L)
     spp_t *parser = *udata;
 
     const char *input = luaL_checkstring(L, 2);
+#if LUA_VERSION_NUM >= 502
+    size_t size = lua_rawlen(L, 2);
+#else
+    size_t size = lua_objlen(L, 2);
+#endif
 
-    if (spp_feed(parser, (char *)input) != SPP_OK)
+    if (spp_feed(parser, (char *)input, size) != SPP_OK)
         luaL_error(L, "No memory");
     return 0;
 }


### PR DESCRIPTION
This ports the null byte bugfix from hit9/spp_py#2 to spp_lua. I've tested on lua 5.1, 5.2 & 5.3.

**Example:**
```lua
local spp = require('spp_lua')
local parser = spp:new()

parser:feed("2\nok\n5\nbo\0dy\n\n")

while true do
    res = parser:get()
    if res == nil then 
        break
    else
        for i=1, #res do print(res[i]) end
    end
end
```
The example will output `ok\nbo\0dy` on lua 5.2 and 5.3 and `ok\nbo` on lua 5.1.
That's because `print` in lua 5.1 uses `printf` – you can check with `string.len(res[i])` and it will return the correct `2\n5` on 5.1/5.2/5.3.

I've also made small change to bench.lua to support sub-second precision:
```bash
# before:
$ lua5.3 bench.lua
spp parser: 500000 in 1.000000s => 500000.000000ops
lua parser: 500000 in 3.000000s => 166666.666667ops
# after:
$ lua5.3 bench.lua
spp parser: 500000 in 1.198362s => 417236.194072ops
lua parser: 500000 in 2.325170s => 215038.040229ops
```